### PR TITLE
Fix typos in package summary.

### DIFF
--- a/polymer.go
+++ b/polymer.go
@@ -14,11 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// The polymer library can be used to work with polymer using GopherJS instead of having to write straight up javascript
+// The polymer library can be used to work with polymer using GopherJS instead of having to write straight up JavaScript.
 // Simple examples to get started are available in the examples/ subfolder. It is highly recommend to go through them.
 //
 // The polymer website itself also has a great deal of information on how to get started, most of the information available there
-// also applies to the Go bindings of polymer
+// also applies to the Go bindings of polymer.
 package polymer // import "code.palmstonegames.com/polymer"
 
 import (


### PR DESCRIPTION
Hi there,

After reading it at https://godoc.org/code.palmstonegames.com/polymer, I'd like to propose these improvements to the package documentation:
- Add missing periods at ends of sentences.
- Use correct spelling for JavaScript language, according to https://en.wikipedia.org/wiki/JavaScript#cite_ref-5.

I was also considering changing "polymer" to "Polymer", since that appears to be the correct spelling according to their website, but I wasn't as confident about it. I'll leave it to you to consider.
