### PR TITLE
fix caddy prerequisite

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -29,5 +29,5 @@ $ go get github.com/gopherjs/gopherjs
 ```
 Caddy 
 ```
-$ go get github.com/mholt/caddy
+$ go get github.com/mholt/caddy/caddy
 ```


### PR DESCRIPTION
The go get address did not install the caddy command, see https://github.com/mholt/caddy#running-from-source.
